### PR TITLE
Rename 6502Retro to PD6502 in examples and board library

### DIFF
--- a/Source/Library/Boards/PD6502.hs
+++ b/Source/Library/Boards/PD6502.hs
@@ -34,5 +34,5 @@ unit Board
     uses "/Source/Minimal/System"
     uses "/Source/Minimal/MCU"
     
-    string BoardName { get { return "6502-Retro"; } }
+    string BoardName { get { return "PD6502"; } }
 }

--- a/Source/Testing/Minimal/Blink.hs
+++ b/Source/Testing/Minimal/Blink.hs
@@ -2,7 +2,7 @@ program Blink
 {
     uses "/Source/Library/Boards/Hopper6502"
     //uses "/Source/Library/Boards/BenEater6502"
-    //uses "/Source/Library/Boards/6502Retro"
+    //uses "/Source/Library/Boards/PD6502"
     //uses "/Source/Library/Boards/PiPico"
     
     Hopper()

--- a/Source/Testing/Minimal/HighLow.hs
+++ b/Source/Testing/Minimal/HighLow.hs
@@ -1,8 +1,8 @@
 program HighLow
 {
     //uses "/Source/Library/Boards/Hopper6502"
-    uses "/Source/Library/Boards/BenEater6502"
-    //uses "/Source/Library/Boards/6502Retro"
+    //uses "/Source/Library/Boards/BenEater6502"
+    uses "/Source/Library/Boards/PD6502"
     
     Hopper() {
         IO.WriteLn();

--- a/Source/Testing/Minimal/HighLow.hs
+++ b/Source/Testing/Minimal/HighLow.hs
@@ -1,8 +1,8 @@
 program HighLow
 {
-    //uses "/Source/Library/Boards/Hopper6502"
+    uses "/Source/Library/Boards/Hopper6502"
     //uses "/Source/Library/Boards/BenEater6502"
-    uses "/Source/Library/Boards/PD6502"
+    //uses "/Source/Library/Boards/PD6502"
     
     Hopper() {
         IO.WriteLn();


### PR DESCRIPTION
Following discussion on Discord, the 6502-Retro! board will be renamed in Hopper to PD6502 to comply with naming standards in the Hopper Filesystem and elsewhere in the Hopper ecosystem.

This PR delivers the following changes:

- Rename the board in /Source/Library/Boards/ from 6502Retro.hs to PD6502.hs (also returns the correct board name)
- Update the following examples in /Source/Testing/Minimal/ to reflect the board name change.
    - Blink.hs
    - HighLow.hs